### PR TITLE
Expose more edge options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,23 @@ export const Graph = (props) => {
 
 The `SmartEdge` takes the same options as a [React Flow Edge](https://reactflow.dev/docs/api/edges/).
 
-You can configure additional options wrapping your graph with `SmartEdgeProvider` and passing an options `value`. The available options are:
+You can configure additional advanced options by wrapping your graph with `SmartEdgeProvider` and passing an `options` object. If an option is not provided it'll assume it's default value. The available options are:
 
 ```js
 const options = {
-  // Configure by how many milliseconds the Edge render should be debounced, default 200, pass 0 to disable.
-  debounceTime: 100,
+  // Configure by how many milliseconds the Edge render should be
+  //debounced. Default 200, 0 to disable.
+  debounceTime: 200,
+
+  // How many pixels of padding is added around nodes, or by how
+  // much should the edge avoid the walls of a node. Default 10,
+  // minimum 2.
+  nodePadding: 10,
+
+  // The size in pixels of each square grid cell used for path
+  // finding. Smaller values for a more accurate path, bigger
+  // for faster path finding. Default 10, minimum 2.
+  gridRatio: 10,
 };
 ```
 
@@ -78,7 +89,7 @@ export const Graph = (props) => {
   const { children, ...rest } = props;
 
   return (
-    <SmartEdgeProvider value={{ debounceTime: 300 }}>
+    <SmartEdgeProvider options={{ debounceTime: 300 }}>
       <ReactFlow
         elements={elements}
         edgeTypes={{

--- a/src/SmartEdge/createGrid.ts
+++ b/src/SmartEdge/createGrid.ts
@@ -4,11 +4,9 @@ import {
   getNextPointFromPosition,
 } from './guaranteeWalkablePath';
 import { graphToGridPoint } from './pointConversion';
-import { round } from './utils';
+import { round, roundUp } from './utils';
 import type { NodeBoundingBox, GraphBoundingBox } from './getBoundingBoxes';
 import type { Position } from 'react-flow-renderer';
-
-export const gridRatio = 10;
 
 export type PointInfo = {
   x: number;
@@ -20,21 +18,22 @@ export const createGrid = (
   graph: GraphBoundingBox,
   nodes: NodeBoundingBox[],
   source: PointInfo,
-  target: PointInfo
+  target: PointInfo,
+  gridRatio = 2
 ) => {
   const { xMin, yMin, width, height } = graph;
 
   // Create a grid representation of the graph box, where each cell is
   // equivalent to 10x10 pixels on the graph. We'll use this  simplified grid
   // to do pathfinding.
-  const mapColumns = width / gridRatio;
-  const mapRows = height / gridRatio;
+  const mapColumns = roundUp(width, gridRatio) / gridRatio + 1;
+  const mapRows = roundUp(height, gridRatio) / gridRatio + 1;
   const grid = new Grid(mapColumns, mapRows);
 
   // Update the grid representation with the space the nodes take up
   nodes.forEach((node) => {
-    const nodeStart = graphToGridPoint(node.topLeft, xMin, yMin);
-    const nodeEnd = graphToGridPoint(node.bottomRight, xMin, yMin);
+    const nodeStart = graphToGridPoint(node.topLeft, xMin, yMin, gridRatio);
+    const nodeEnd = graphToGridPoint(node.bottomRight, xMin, yMin, gridRatio);
 
     for (let x = nodeStart.x; x < nodeEnd.x; x++) {
       for (let y = nodeStart.y; y < nodeEnd.y; y++) {
@@ -50,7 +49,8 @@ export const createGrid = (
       y: round(source.y, gridRatio),
     },
     xMin,
-    yMin
+    yMin,
+    gridRatio
   );
 
   const endGrid = graphToGridPoint(
@@ -59,7 +59,8 @@ export const createGrid = (
       y: round(target.y, gridRatio),
     },
     xMin,
-    yMin
+    yMin,
+    gridRatio
   );
 
   // Guarantee a walkable path between the start and end points, even if the

--- a/src/SmartEdge/getBoundingBoxes.ts
+++ b/src/SmartEdge/getBoundingBoxes.ts
@@ -29,26 +29,15 @@ export type GraphBoundingBox = {
  * of all corner points.
  *
  * @param storeNodes The node list
- * @param nodePadding Optional padding to add to the node's bounding boxes
- * @param graphPadding Optional padding to add to the graph's bounding box
- * @param roundTo If the coordinates should be rounded to this nearest integer
+ * @param nodePadding Optional padding to add to the node's and graph bounding boxes
+ * @param roundTo Everything will be rounded to this nearest integer
  * @returns Graph and nodes bounding boxes.
  */
 export const getBoundingBoxes = (
   storeNodes: Node[],
-  nodePadding = 0,
-  graphPadding = 0,
-  roundTo = 0
+  nodePadding = 2,
+  roundTo = 2
 ) => {
-  // Guarantee that the given parameters are positive integers
-  nodePadding = Math.max(Math.round(nodePadding), 0);
-  graphPadding = Math.max(Math.round(graphPadding), 0);
-  roundTo = Math.max(Math.round(roundTo), 0);
-
-  nodePadding = Number.isInteger(nodePadding) ? nodePadding : 0;
-  graphPadding = Number.isInteger(graphPadding) ? graphPadding : 0;
-  roundTo = Number.isInteger(roundTo) ? roundTo : 0;
-
   let xMax = Number.MIN_SAFE_INTEGER;
   let yMax = Number.MIN_SAFE_INTEGER;
   let xMin = Number.MAX_SAFE_INTEGER;
@@ -107,10 +96,12 @@ export const getBoundingBoxes = (
     };
   });
 
-  xMax = xMax + graphPadding;
-  yMax = yMax + graphPadding;
-  xMin = xMin - graphPadding;
-  yMin = yMin - graphPadding;
+  const graphPadding = nodePadding * 2;
+
+  xMax = roundUp(xMax + graphPadding, roundTo);
+  yMax = roundUp(yMax + graphPadding, roundTo);
+  xMin = roundDown(xMin - graphPadding, roundTo);
+  yMin = roundDown(yMin - graphPadding, roundTo);
 
   const topLeft: XYPosition = {
     x: xMin,

--- a/src/SmartEdge/index.tsx
+++ b/src/SmartEdge/index.tsx
@@ -6,7 +6,7 @@ import {
   useStoreState,
   EdgeText,
 } from 'react-flow-renderer';
-import { createGrid, PointInfo, gridRatio } from './createGrid';
+import { createGrid, PointInfo } from './createGrid';
 import { drawSmoothLinePath } from './drawSvgPath';
 import { generatePath } from './generatePath';
 import { getBoundingBoxes } from './getBoundingBoxes';
@@ -17,10 +17,6 @@ import { SmartEdgeContext, SmartEdgeProvider, useSmartEdge } from './context';
 interface PathFindingEdgeProps<T = any> extends EdgeProps<T> {
   storeNodes: Node<T>[];
 }
-
-const nodePadding = 10;
-const graphPadding = 20;
-const roundCoordinatesTo = gridRatio;
 
 const PathFindingEdge = memo((props: PathFindingEdgeProps) => {
   const {
@@ -42,12 +38,14 @@ const PathFindingEdge = memo((props: PathFindingEdgeProps) => {
     labelBgBorderRadius,
   } = props;
 
+  const { gridRatio, nodePadding } = useSmartEdge();
+  const roundCoordinatesTo = gridRatio;
+
   // We use the node's information to generate bounding boxes for them
   // and the graph
   const { graph, nodes } = getBoundingBoxes(
     storeNodes,
     nodePadding,
-    graphPadding,
     roundCoordinatesTo
   );
 
@@ -65,7 +63,13 @@ const PathFindingEdge = memo((props: PathFindingEdgeProps) => {
 
   // With this information, we can create a 2D grid representation of
   // our graph, that tells us where in the graph there is a "free" space or not
-  const { grid, start, end } = createGrid(graph, nodes, source, target);
+  const { grid, start, end } = createGrid(
+    graph,
+    nodes,
+    source,
+    target,
+    gridRatio
+  );
 
   // We then can use the grid representation to do pathfinding
   const { fullPath, smoothedPath } = generatePath(grid, start, end);
@@ -83,7 +87,12 @@ const PathFindingEdge = memo((props: PathFindingEdgeProps) => {
   // Here we convert the grid path to a sequence of graph coordinates.
   const graphPath = smoothedPath.map((gridPoint) => {
     const [x, y] = gridPoint;
-    const graphPoint = gridToGraphPoint({ x, y }, graph.xMin, graph.yMin);
+    const graphPoint = gridToGraphPoint(
+      { x, y },
+      graph.xMin,
+      graph.yMin,
+      gridRatio
+    );
     return [graphPoint.x, graphPoint.y];
   });
 
@@ -95,7 +104,8 @@ const PathFindingEdge = memo((props: PathFindingEdgeProps) => {
   const { x: labelX, y: labelY } = gridToGraphPoint(
     { x: middleX, y: middleY },
     graph.xMin,
-    graph.yMin
+    graph.yMin,
+    gridRatio
   );
 
   const text = label ? (

--- a/src/SmartEdge/pointConversion.ts
+++ b/src/SmartEdge/pointConversion.ts
@@ -1,7 +1,5 @@
 import type { XYPosition } from 'react-flow-renderer';
 
-const gridRatio = 10;
-
 /**
  * Each bounding box is a collection of X/Y points in a graph, and we
  * need to convert them to "occupied" cells in a 2D grid representation.
@@ -25,7 +23,8 @@ const gridRatio = 10;
 export const graphToGridPoint = (
   graphPoint: XYPosition,
   smallestX: number,
-  smallestY: number
+  smallestY: number,
+  gridRatio: number
 ): XYPosition => {
   let x = graphPoint.x / gridRatio;
   let y = graphPoint.y / gridRatio;
@@ -67,7 +66,8 @@ export const graphToGridPoint = (
 export const gridToGraphPoint = (
   gridPoint: XYPosition,
   smallestX: number,
-  smallestY: number
+  smallestY: number,
+  gridRatio: number
 ): XYPosition => {
   let x = gridPoint.x * gridRatio;
   let y = gridPoint.y * gridRatio;

--- a/src/SmartEdge/utils.ts
+++ b/src/SmartEdge/utils.ts
@@ -6,3 +6,10 @@ export const roundDown = (x: number, multiple = 10) =>
 
 export const roundUp = (x: number, multiple = 10) =>
   Math.ceil(x / multiple) * multiple;
+
+export const toInteger = (value: number, min = 0) => {
+  let result = Math.max(Math.round(value), min);
+  result = Number.isInteger(result) ? result : min;
+  result = result >= min ? result : min;
+  return result;
+};

--- a/stories/SmartEdge/Graph.tsx
+++ b/stories/SmartEdge/Graph.tsx
@@ -39,7 +39,7 @@ export const GraphWithProvider = ({
   ...rest
 }: GraphWithProviderProps) => {
   return (
-    <SmartEdgeProvider value={options}>
+    <SmartEdgeProvider options={options}>
       <Graph {...rest} />
     </SmartEdgeProvider>
   );

--- a/stories/SmartEdge/SmartEdge.stories.tsx
+++ b/stories/SmartEdge/SmartEdge.stories.tsx
@@ -25,9 +25,16 @@ const TemplateWithProvider: Story<GraphWithProviderProps> = (args) => (
   <GraphWithProvider {...args} />
 );
 
+const defaultOptions = {
+  debounceTime: 200,
+  nodePadding: 10,
+  gridRatio: 10,
+};
+
 export const smallerDebounce = TemplateWithProvider.bind({});
 smallerDebounce.args = {
   options: {
+    ...defaultOptions,
     debounceTime: 50,
   },
   elements: data,
@@ -36,7 +43,44 @@ smallerDebounce.args = {
 export const noDebounce = TemplateWithProvider.bind({});
 noDebounce.args = {
   options: {
+    ...defaultOptions,
     debounceTime: 0,
+  },
+  elements: data,
+};
+
+export const biggerNodePadding = TemplateWithProvider.bind({});
+biggerNodePadding.args = {
+  options: {
+    ...defaultOptions,
+    nodePadding: 20,
+  },
+  elements: data,
+};
+
+export const smallerNodePadding = TemplateWithProvider.bind({});
+smallerNodePadding.args = {
+  options: {
+    ...defaultOptions,
+    nodePadding: 8,
+  },
+  elements: data,
+};
+
+export const biggerGridRatio = TemplateWithProvider.bind({});
+biggerGridRatio.args = {
+  options: {
+    ...defaultOptions,
+    gridRatio: 15,
+  },
+  elements: data,
+};
+
+export const smallerGridRatio = TemplateWithProvider.bind({});
+smallerGridRatio.args = {
+  options: {
+    ...defaultOptions,
+    gridRatio: 6,
   },
   elements: data,
 };


### PR DESCRIPTION
Expose node padding and grid ratio options. Closes issue https://github.com/tisoap/react-flow-smart-edge/issues/5.

Breaking change: renamed `value` prop to `options`.