### PR TITLE
Upgrade to @xyflow/react@12

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import 'reactflow/dist/style.css'
+import '@xyflow/react/dist/style.css'
 
 // https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters
 export const parameters = {

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Each one can be imported individually as a named export.
 
 ```jsx
 import React from 'react'
-import { ReactFlow } from 'reactflow'
+import { ReactFlow } from '@xyflow/react'
 import { SmartBezierEdge } from '@tisoap/react-flow-smart-edge'
-import 'reactflow/dist/style.css'
+import '@xyflow/react/dist/style.css'
 
 const nodes = [
 	{
@@ -116,7 +116,7 @@ Just like you can use `getBezierPath` from `reactflow` to create a [custom edge 
 
 ```jsx
 import React from 'react'
-import { useNodes, BezierEdge } from 'reactflow'
+import { useNodes, BezierEdge } from '@xyflow/react'
 import { getSmartEdge } from '@tisoap/react-flow-smart-edge'
 
 const foreignObjectSize = 200

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
 		"@storybook/test-runner": "^0.13.0",
 		"@storybook/testing-library": "^0.2.0",
 		"@storybook/theming": "^7.4.0",
+		"@storybook/types": "^7.6.0",
 		"@tisoap/eslint-config-ts-react": "^7.0.0",
 		"@types/minimist": "^1.2.2",
 		"@types/node": "^20.6.0",
@@ -86,6 +87,7 @@
 		"@types/react-dom": "^18.0.9",
 		"@typescript-eslint/eslint-plugin": "^6.6.0",
 		"@typescript-eslint/parser": "^6.6.0",
+		"@xyflow/react": "^12.4.4",
 		"chromatic": "^7.1.0",
 		"concurrently": "^8.2.1",
 		"dts-cli": "^2.0.3",
@@ -114,19 +116,19 @@
 		"prettier": "^3.0.3",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"reactflow": "^11.2.0",
 		"require-from-string": "^2.0.2",
 		"storybook": "^7.4.0",
 		"string-width": "^4.2.3",
 		"strip-ansi": "^6.0.1",
+		"tslib": "^2.8.1",
 		"typescript": "^5.2.2",
 		"wait-on": "^7.0.1",
 		"webpack": "^5.75.0"
 	},
 	"peerDependencies": {
+		"@xyflow/react": ">=12",
 		"react": ">=17",
 		"react-dom": ">=17",
-		"reactflow": ">=11",
 		"typescript": ">=4.6"
 	},
 	"engines": {

--- a/src/SmartBezierEdge/index.tsx
+++ b/src/SmartBezierEdge/index.tsx
@@ -1,9 +1,9 @@
+import { BezierEdge, useNodes } from '@xyflow/react'
 import React from 'react'
-import { useNodes, BezierEdge } from 'reactflow'
 import { SmartEdge } from '../SmartEdge'
-import { svgDrawSmoothLinePath, pathfindingAStarDiagonal } from '../functions'
+import { pathfindingAStarDiagonal, svgDrawSmoothLinePath } from '../functions'
 import type { SmartEdgeOptions } from '../SmartEdge'
-import type { EdgeProps } from 'reactflow'
+import type { Edge, EdgeProps, Node } from '@xyflow/react'
 
 const BezierConfiguration: SmartEdgeOptions = {
 	drawEdge: svgDrawSmoothLinePath,
@@ -11,9 +11,10 @@ const BezierConfiguration: SmartEdgeOptions = {
 	fallback: BezierEdge
 }
 
-export function SmartBezierEdge<EdgeDataType = unknown, NodeDataType = unknown>(
-	props: EdgeProps<EdgeDataType>
-) {
+export function SmartBezierEdge<
+	EdgeDataType extends Edge = Edge,
+	NodeDataType extends Node = Node
+>(props: EdgeProps<EdgeDataType>): React.JSX.Element {
 	const nodes = useNodes<NodeDataType>()
 
 	return (

--- a/src/SmartEdge/index.tsx
+++ b/src/SmartEdge/index.tsx
@@ -1,8 +1,8 @@
+import { BaseEdge, BezierEdge } from '@xyflow/react'
 import React from 'react'
-import { BezierEdge, BaseEdge } from 'reactflow'
 import { getSmartEdge } from '../getSmartEdge'
 import type { GetSmartEdgeOptions } from '../getSmartEdge'
-import type { EdgeProps, Node } from 'reactflow'
+import type { Edge, EdgeProps, Node } from '@xyflow/react'
 
 export type EdgeElement = typeof BezierEdge
 
@@ -10,13 +10,18 @@ export type SmartEdgeOptions = GetSmartEdgeOptions & {
 	fallback?: EdgeElement
 }
 
-export interface SmartEdgeProps<EdgeDataType = unknown, NodeDataType = unknown>
-	extends EdgeProps<EdgeDataType> {
-	nodes: Node<NodeDataType>[]
+export interface SmartEdgeProps<
+	EdgeDataType extends Edge = Edge,
+	NodeDataType extends Node = Node
+> extends EdgeProps<EdgeDataType> {
+	nodes: NodeDataType[]
 	options: SmartEdgeOptions
 }
 
-export function SmartEdge<EdgeDataType = unknown, NodeDataType = unknown>({
+export function SmartEdge<
+	EdgeDataType extends Edge = Edge,
+	NodeDataType extends Node = Node
+>({
 	nodes,
 	options,
 	...edgeProps

--- a/src/SmartStepEdge/index.tsx
+++ b/src/SmartStepEdge/index.tsx
@@ -1,22 +1,24 @@
+import { StepEdge, useNodes } from '@xyflow/react'
 import React from 'react'
-import { useNodes, StepEdge } from 'reactflow'
 import { SmartEdge } from '../SmartEdge'
 import {
-	svgDrawStraightLinePath,
-	pathfindingJumpPointNoDiagonal
+	pathfindingJumpPointNoDiagonal,
+	svgDrawStraightLinePath
 } from '../functions'
 import type { SmartEdgeOptions } from '../SmartEdge'
-import type { EdgeProps } from 'reactflow'
+import type { Edge, EdgeProps, Node } from '@xyflow/react'
 
 const StepConfiguration: SmartEdgeOptions = {
 	drawEdge: svgDrawStraightLinePath,
 	generatePath: pathfindingJumpPointNoDiagonal,
+	// @ts-expect-error error with bezieredge?
 	fallback: StepEdge
 }
 
-export function SmartStepEdge<EdgeDataType = unknown, NodeDataType = unknown>(
-	props: EdgeProps<EdgeDataType>
-) {
+export function SmartStepEdge<
+	EdgeDataType extends Edge = Edge,
+	NodeDataType extends Node = Node
+>(props: EdgeProps<EdgeDataType>) {
 	const nodes = useNodes<NodeDataType>()
 
 	return (

--- a/src/SmartStraightEdge/index.tsx
+++ b/src/SmartStraightEdge/index.tsx
@@ -1,12 +1,12 @@
+import { StraightEdge, useNodes } from '@xyflow/react'
 import React from 'react'
-import { useNodes, StraightEdge } from 'reactflow'
 import { SmartEdge } from '../SmartEdge'
 import {
-	svgDrawStraightLinePath,
-	pathfindingAStarNoDiagonal
+	pathfindingAStarNoDiagonal,
+	svgDrawStraightLinePath
 } from '../functions'
 import type { SmartEdgeOptions } from '../SmartEdge'
-import type { EdgeProps } from 'reactflow'
+import type { Edge, EdgeProps, Node } from '@xyflow/react'
 
 const StraightConfiguration: SmartEdgeOptions = {
 	drawEdge: svgDrawStraightLinePath,
@@ -15,8 +15,8 @@ const StraightConfiguration: SmartEdgeOptions = {
 }
 
 export function SmartStraightEdge<
-	EdgeDataType = unknown,
-	NodeDataType = unknown
+	EdgeDataType extends Edge = Edge,
+	NodeDataType extends Node = Node
 >(props: EdgeProps<EdgeDataType>) {
 	const nodes = useNodes<NodeDataType>()
 

--- a/src/functions/createGrid.ts
+++ b/src/functions/createGrid.ts
@@ -1,12 +1,12 @@
 import { Grid } from 'pathfinding'
 import {
-	guaranteeWalkablePath,
-	getNextPointFromPosition
+	getNextPointFromPosition,
+	guaranteeWalkablePath
 } from './guaranteeWalkablePath'
 import { graphToGridPoint } from './pointConversion'
 import { round, roundUp } from './utils'
-import type { NodeBoundingBox, GraphBoundingBox } from './getBoundingBoxes'
-import type { Position } from 'reactflow'
+import type { GraphBoundingBox, NodeBoundingBox } from './getBoundingBoxes'
+import type { Position } from '@xyflow/react'
 
 export type PointInfo = {
 	x: number

--- a/src/functions/drawSvgPath.ts
+++ b/src/functions/drawSvgPath.ts
@@ -1,4 +1,4 @@
-import type { XYPosition } from 'reactflow'
+import type { XYPosition } from '@xyflow/react'
 
 /**
  * Takes source and target {x, y} points, together with an array of number

--- a/src/functions/generatePath.ts
+++ b/src/functions/generatePath.ts
@@ -7,12 +7,12 @@
 */
 import {
 	AStarFinder,
+	DiagonalMovement,
 	JumpPointFinder,
-	Util,
-	DiagonalMovement
+	Util
 } from 'pathfinding'
+import type { XYPosition } from '@xyflow/react'
 import type { Grid } from 'pathfinding'
-import type { XYPosition } from 'reactflow'
 
 /**
  * Takes source and target {x, y} points, together with an grid representation

--- a/src/functions/getBoundingBoxes.ts
+++ b/src/functions/getBoundingBoxes.ts
@@ -1,5 +1,5 @@
-import { roundDown, roundUp } from './utils'
 import type { Node, XYPosition } from '@xyflow/react'
+import { roundDown, roundUp } from './utils'
 
 export type NodeBoundingBox = {
 	id: string
@@ -44,8 +44,8 @@ export const getBoundingBoxes = <NodeDataType extends Node = Node>(
 	let yMin = Number.MAX_SAFE_INTEGER
 
 	const nodeBoxes: NodeBoundingBox[] = nodes.map((node) => {
-		const width = Math.max(node.width || 0, 1)
-		const height = Math.max(node.height || 0, 1)
+		const width = Math.max(node.width ?? node.measured?.width ?? 0, 1)
+		const height = Math.max(node.height ?? node.measured?.height ?? 0, 1)
 
 		const position: XYPosition = {
 			x: node.position.x || 0,

--- a/src/functions/getBoundingBoxes.ts
+++ b/src/functions/getBoundingBoxes.ts
@@ -1,5 +1,5 @@
-import { roundUp, roundDown } from './utils'
-import type { Node, XYPosition } from 'reactflow'
+import { roundDown, roundUp } from './utils'
+import type { Node, XYPosition } from '@xyflow/react'
 
 export type NodeBoundingBox = {
 	id: string
@@ -33,8 +33,8 @@ export type GraphBoundingBox = {
  * @param roundTo Everything will be rounded to this nearest integer
  * @returns Graph and nodes bounding boxes.
  */
-export const getBoundingBoxes = <NodeDataType = unknown>(
-	nodes: Node<NodeDataType>[],
+export const getBoundingBoxes = <NodeDataType extends Node = Node>(
+	nodes: NodeDataType[],
 	nodePadding = 2,
 	roundTo = 2
 ) => {
@@ -48,8 +48,8 @@ export const getBoundingBoxes = <NodeDataType = unknown>(
 		const height = Math.max(node.height || 0, 1)
 
 		const position: XYPosition = {
-			x: node.positionAbsolute?.x || 0,
-			y: node.positionAbsolute?.y || 0
+			x: node.position.x || 0,
+			y: node.position.y || 0
 		}
 
 		const topLeft: XYPosition = {

--- a/src/functions/guaranteeWalkablePath.ts
+++ b/src/functions/guaranteeWalkablePath.ts
@@ -1,5 +1,5 @@
+import type { Position, XYPosition } from '@xyflow/react'
 import type { Grid } from 'pathfinding'
-import type { Position, XYPosition } from 'reactflow'
 
 type Direction = 'top' | 'bottom' | 'left' | 'right'
 

--- a/src/functions/pointConversion.ts
+++ b/src/functions/pointConversion.ts
@@ -1,4 +1,4 @@
-import type { XYPosition } from 'reactflow'
+import type { XYPosition } from '@xyflow/react'
 
 /**
  * Each bounding box is a collection of X/Y points in a graph, and we

--- a/src/getSmartEdge/index.ts
+++ b/src/getSmartEdge/index.ts
@@ -7,11 +7,11 @@ import {
 	toInteger
 } from '../functions'
 import type {
-	PointInfo,
 	PathFindingFunction,
+	PointInfo,
 	SVGDrawFunction
 } from '../functions'
-import type { Node, EdgeProps } from 'reactflow'
+import type { EdgeProps, Node } from '@xyflow/react'
 
 export type EdgeParams = Pick<
 	EdgeProps,
@@ -30,10 +30,11 @@ export type GetSmartEdgeOptions = {
 	generatePath?: PathFindingFunction
 }
 
-export type GetSmartEdgeParams<NodeDataType = unknown> = EdgeParams & {
-	options?: GetSmartEdgeOptions
-	nodes: Node<NodeDataType>[]
-}
+export type GetSmartEdgeParams<NodeDataType extends Node = Node> =
+	EdgeParams & {
+		options?: GetSmartEdgeOptions
+		nodes: NodeDataType[]
+	}
 
 export type GetSmartEdgeReturn = {
 	svgPathString: string
@@ -41,7 +42,7 @@ export type GetSmartEdgeReturn = {
 	edgeCenterY: number
 }
 
-export const getSmartEdge = <NodeDataType = unknown>({
+export const getSmartEdge = <NodeDataType extends Node = Node>({
 	options = {},
 	nodes = [],
 	sourceX,

--- a/src/stories/CustomLabel.tsx
+++ b/src/stories/CustomLabel.tsx
@@ -1,12 +1,12 @@
+import { BezierEdge, useNodes } from '@xyflow/react'
 import React from 'react'
-import { useNodes, BezierEdge } from 'reactflow'
 import { getSmartEdge } from '../getSmartEdge'
 import type { EdgeData, NodeData } from './DummyData'
-import type { EdgeProps } from 'reactflow'
+import type { Edge, EdgeProps, Node } from '@xyflow/react'
 
 const size = 20
 
-export function SmartEdgeCustomLabel(props: EdgeProps<EdgeData>) {
+export function SmartEdgeCustomLabel(props: EdgeProps<Edge<EdgeData>>) {
 	const {
 		id,
 		sourcePosition,
@@ -20,7 +20,7 @@ export function SmartEdgeCustomLabel(props: EdgeProps<EdgeData>) {
 		markerEnd
 	} = props
 
-	const nodes = useNodes<NodeData>()
+	const nodes = useNodes<Node<NodeData>>()
 
 	const getSmartEdgeResponse = getSmartEdge({
 		sourcePosition,

--- a/src/stories/DummyData.ts
+++ b/src/stories/DummyData.ts
@@ -1,7 +1,7 @@
-import { MarkerType } from 'reactflow'
-import { SmartBezierEdge, SmartStraightEdge, SmartStepEdge } from '../index'
+import { MarkerType } from '@xyflow/react'
+import { SmartBezierEdge, SmartStepEdge, SmartStraightEdge } from '../index'
 import { SmartEdgeCustomLabel } from './CustomLabel'
-import type { Node, Edge } from 'reactflow'
+import type { Edge, Node } from '@xyflow/react'
 
 const markerEndType = MarkerType.Arrow
 
@@ -16,7 +16,7 @@ export type NodeData = {
 	label: string
 }
 
-export type EdgeData = { customField: string } | undefined
+export type EdgeData = { customField: string }
 
 export const nodes: Node<NodeData>[] = [
 	{

--- a/src/stories/GraphWrapper.tsx
+++ b/src/stories/GraphWrapper.tsx
@@ -1,6 +1,6 @@
+import { ReactFlow } from '@xyflow/react'
 import React from 'react'
-import { ReactFlow } from 'reactflow'
-import type { ReactFlowProps } from 'reactflow'
+import type { ReactFlowProps } from '@xyflow/react'
 
 const style = {
 	background: '#fafafa',

--- a/src/stories/SmartEdge.stories.tsx
+++ b/src/stories/SmartEdge.stories.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 import {
 	edgesBezier,
-	edgesStraight,
-	edgesStep,
 	edgesLabel,
-	nodes,
-	edgeTypes
+	edgesStep,
+	edgesStraight,
+	edgeTypes,
+	nodes
 } from './DummyData'
 import { GraphWrapper } from './GraphWrapper'
 import type { Meta, Story } from '@storybook/react'
-import type { ReactFlowProps } from 'reactflow'
+import type { ReactFlowProps } from '@xyflow/react'
 
 export default {
 	title: 'Smart Edge',

--- a/src/stories/SmartEdgeInteractions.stories.tsx
+++ b/src/stories/SmartEdgeInteractions.stories.tsx
@@ -2,9 +2,9 @@ import { within } from '@storybook/testing-library'
 import React from 'react'
 import { GraphWrapper } from './GraphWrapper'
 import { SimulateDragAndDrop, wait } from './SimulateDragAndDrop'
-import { SmartBezier, SmartStraight, SmartStep } from './SmartEdge.stories'
+import { SmartBezier, SmartStep, SmartStraight } from './SmartEdge.stories'
 import type { Meta, Story } from '@storybook/react'
-import type { ReactFlowProps } from 'reactflow'
+import type { ReactFlowProps } from '@xyflow/react'
 
 export default {
 	title: 'Interactions',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"include": ["src", ".eslintrc.js", "jest.config.js"],
 	"compilerOptions": {
 		"baseUrl": "./src",
-		"declaration": true,
+		"declaration": false,
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"importHelpers": true,


### PR DESCRIPTION
This has all of the import updates and type annotation updates to successfully upgrade to `@xyflow/react@12`

This appears to fix #61 

There are several loose ends, I think:

- [x] I need to test this on my own code base and make sure it works
- [ ] `declaration: true` in `tsconfig.json` was causing problems with the Storybook stories. We need to either keep it as `false` or we need to explicitly declare story types. We also can probably remove the `@storybook/types` package as that appears to not do anything.
- [ ] It felt weird that I could not build without `tslib` - can we keep it?