### PR TITLE
fix: remove typescript from peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,8 +60,7 @@
       "peerDependencies": {
         "@xyflow/react": ">=12",
         "react": ">=18",
-        "react-dom": ">=18",
-        "typescript": ">=5"
+        "react-dom": ">=18"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -119,8 +119,7 @@
   "peerDependencies": {
     "@xyflow/react": ">=12",
     "react": ">=18",
-    "react-dom": ">=18",
-    "typescript": ">=5"
+    "react-dom": ">=18"
   },
   "allowScripts": {
     "esbuild@0.28.1": true,


### PR DESCRIPTION
## Summary
- Remove `typescript` from `peerDependencies` (build-time only; not a runtime peer)
- Keep `typescript` in `devDependencies`; leave `react` / `react-dom` / `@xyflow/react` peers unchanged
- Sync root `package-lock.json` peers to match

Fixes #70

## Test plan
- [x] Inspect packed `package.json` peers: no `typescript`; runtime peers remain
- [x] Confirm `devDependencies.typescript` still present
- [ ] Maintainer: patch release so npm consumers pick up the change